### PR TITLE
Fixed "Convert links" when the "title" has brackets inside

### DIFF
--- a/chatgpt_md_converter/telegram_formatter.py
+++ b/chatgpt_md_converter/telegram_formatter.py
@@ -40,7 +40,7 @@ def telegram_format(text: str) -> str:
     output = re.sub(r"【[^】]+】", "", output)
 
     # Convert links
-    output = re.sub(r"!?\[(.*?)\]\((.*?)\)", r'<a href="\2">\1</a>', output)
+    output = re.sub(r"(?<!\!)\[((?:[^\[\]]|\[.*?\])*)\]\((.*?)\)", r'<a href="\2">\1</a>', output)
 
     # Convert headings
     output = re.sub(r"^\s*#+ (.+)", r"<b>\1</b>", output, flags=re.MULTILINE)


### PR DESCRIPTION
Cases like, `"[OtherText] [Title](Link)"`
Results in:
`'<a href="Link">OtherText] [Title</a>'`

my commit fix that.
